### PR TITLE
Updated GitHub references and defined language env variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libyaml-dev \
         wget
 
-# Build from the head of SATOSA master
-ENV SATOSA_PIP_TARGET=git+git://github.com/IdentityPython/SATOSA.git@79abc46f9a870048b9600357cca4ab9e86df8b57
+# Build from PR 243 until it is merged
+ENV SATOSA_PIP_TARGET=git+git://github.com/IdentityPython/SATOSA.git@refs/pull/243/merge
 
-# Build pysaml2 using a specific PR until merged
-ENV PYSAML2_PIP_TARGET=git+git://github.com/IdentityPython/pysaml2.git@refs/pull/621/merge
+# Build pysaml2 using a specific commit
+ENV PYSAML2_PIP_TARGET=git+git://github.com/IdentityPython/pysaml2.git@322a5f64006cf795179005f772b494e6030028bb
 
 RUN pip3 install --upgrade pip setuptools
 RUN pip3 install ldap3
@@ -24,4 +24,10 @@ RUN pip3 install ${SATOSA_PIP_TARGET}
 
 COPY start.sh /tmp/satosa/start.sh
 COPY attributemaps /tmp/satosa/attributemaps
+
+# Set language to prevent errors when breaking
+# into the container to run satosa-saml-metadata.
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
 ENTRYPOINT ["/tmp/satosa/start.sh"]


### PR DESCRIPTION
Updated the GitHub reference for SATOSA to use PR 243 until
it is merged. Also update the reference for pysaml2 to a specific
commit now that the PR for enhanced eduPersonTargetedID functionality
has been merged. Defined LC_ALL and LANG environment variables so
that it is easier to break into the container and run
satosa-saml-metadata.