### PR TITLE
Bump swamid-plugins to v0.1.0

### DIFF
--- a/versions/8.0.1/requirements.txt
+++ b/versions/8.0.1/requirements.txt
@@ -1,2 +1,2 @@
 SATOSA==8.0.1
-swamid-plugins==0.0.1
+swamid-plugins==0.1.0


### PR DESCRIPTION
Use swamid-plugins `v0.1.0` in order to have access to the new MFAFlagger micro-service.