### PR TITLE
Use own struct to expose supported attribute mappings

### DIFF
--- a/attributemaps/__init__.py
+++ b/attributemaps/__init__.py
@@ -1,5 +1,6 @@
-from saml2.attributemaps import __all__
+from saml2.attributemaps import __all__ as __saml2_builtin_all__
 
 
+__all__ = [*__saml2_builtin_all__]
 if "unspecified" not in __all__:
     __all__.append("unspecified")


### PR DESCRIPTION
- Avoid mutating global state from builtin attribute maps
- Fix `ac_factory` invocation issue when satosa backend and frontends have different configurations with regards to attribute mappings