### PR TITLE
Listen on both v4 and v6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,14 @@ versions.txt:
 
 build: .requirements.txt
 	@docker build --build-arg version=$(VERSION) --no-cache=true -t $(NAME):$(VERSION) .
-	@docker tag $(NAME):$(VERSION) docker.sunet.se/$(NAME):jocar
+	@docker tag $(NAME):$(VERSION) docker.sunet.se/$(NAME):$(VERSION)
 
 freeze:
 	mkdir -p versions/$(VERSION)
 	test -f versions/$(VERSION)/requirements.txt || docker run --entrypoint=pip3 $(NAME):$(VERSION) freeze > versions/$(VERSION)/requirements.txt
 
 push:
-	@docker push docker.sunet.se/$(NAME):jocar
+	@docker push docker.sunet.se/$(NAME):$(VERSION)
 
 clean:
 	@rm -f .requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,14 @@ versions.txt:
 
 build: .requirements.txt
 	@docker build --build-arg version=$(VERSION) --no-cache=true -t $(NAME):$(VERSION) .
-	@docker tag $(NAME):$(VERSION) docker.sunet.se/$(NAME):$(VERSION)
+	@docker tag $(NAME):$(VERSION) docker.sunet.se/$(NAME):jocar
 
 freeze:
 	mkdir -p versions/$(VERSION)
 	test -f versions/$(VERSION)/requirements.txt || docker run --entrypoint=pip3 $(NAME):$(VERSION) freeze > versions/$(VERSION)/requirements.txt
 
 push:
-	@docker push docker.sunet.se/$(NAME):$(VERSION)
+	@docker push docker.sunet.se/$(NAME):jocar
 
 clean:
 	@rm -f .requirements.txt

--- a/start.sh
+++ b/start.sh
@@ -36,10 +36,10 @@ satosa-saml-metadata proxy_conf.yaml ${DATA_DIR}/metadata.key ${DATA_DIR}/metada
 
 # start the proxy
 if [[ -f https.key && -f https.crt ]]; then # if HTTPS cert is available, use it
-  exec gunicorn --reload --bind [::]:${PROXY_PORT} --keyfile https.key --certfile https.crt \
+  exec gunicorn --reload --bind '[::]':${PROXY_PORT} --keyfile https.key --certfile https.crt \
       --workers ${WORKERS} --worker-class ${WORKER_CLASS} --threads ${WORKER_THREADS} \
       --timeout ${WORKER_TIMEOUT} satosa.wsgi:app
 else
-  exec gunicorn --bind [::]:${PROXY_PORT} --workers ${WORKERS} --worker-class ${WORKER_CLASS} \
+  exec gunicorn --bind '[::]':${PROXY_PORT} --workers ${WORKERS} --worker-class ${WORKER_CLASS} \
       --threads ${WORKER_THREADS} --timeout ${WORKER_TIMEOUT} satosa.wsgi:app
 fi

--- a/start.sh
+++ b/start.sh
@@ -36,10 +36,10 @@ satosa-saml-metadata proxy_conf.yaml ${DATA_DIR}/metadata.key ${DATA_DIR}/metada
 
 # start the proxy
 if [[ -f https.key && -f https.crt ]]; then # if HTTPS cert is available, use it
-  exec gunicorn --reload --bind 0.0.0.0:${PROXY_PORT} --keyfile https.key --certfile https.crt \
+  exec gunicorn --reload --bind [::]:${PROXY_PORT} --keyfile https.key --certfile https.crt \
       --workers ${WORKERS} --worker-class ${WORKER_CLASS} --threads ${WORKER_THREADS} \
       --timeout ${WORKER_TIMEOUT} satosa.wsgi:app
 else
-  exec gunicorn --bind 0.0.0.0:${PROXY_PORT} --workers ${WORKERS} --worker-class ${WORKER_CLASS} \
+  exec gunicorn --bind [::]:${PROXY_PORT} --workers ${WORKERS} --worker-class ${WORKER_CLASS} \
       --threads ${WORKER_THREADS} --timeout ${WORKER_TIMEOUT} satosa.wsgi:app
 fi


### PR DESCRIPTION
Since IPV6_V6ONLY [0] isn't true in our machines listning to :: also includes an IPv4-mapped IPv6 address.

E.g
$ /usr/local/bin/python3.9 /usr/local/bin/gunicorn --reload --bind [::]:8002 --keyfile https.key --certfile https.crt --workers 4 --worker-class sync --threads 1 --timeout 60 satosa.wsgi:app $ ss  -patlun | grep :8002
tcp   LISTEN 0      2048               *:8002            *:*    users:(("python3.9",pid=453,fd=7),("python3.9",pid=452,fd=7),("python3.9",pid=451,fd=7),("python3.9",pid=450,fd=7),("python3.9",pid=449,fd=7))

Compared to the old listen:
tcp   LISTEN 0      2048         0.0.0.0:8000      0.0.0.0:*    users:(("python3.9",pid=18,fd=8),("python3.9",pid=17,fd=8),("python3.9",pid=16,fd=8),("python3.9",pid=15,fd=8),("python3.9",pid=1,fd=8))

[0] https://man7.org/linux/man-pages/man7/ipv6.7.html